### PR TITLE
♿️ added href to links so they can be tabbed

### DIFF
--- a/packages/next-templates/src/components/ExampleHeader/ExampleHeader.tsx
+++ b/packages/next-templates/src/components/ExampleHeader/ExampleHeader.tsx
@@ -30,10 +30,12 @@ export const ExampleHeader = ({ ...props }: ExampleHeaderProps) => (
     </div>
     <div className="example--header-items">
       <div className="example--header-links-container">
-        <Link className="example--header-links">
+        <Link className="example--header-links" href="#">
           <User className="example--header-user-icon" /> Mijn omgeving
         </Link>
-        <Link className="example--header-links">Contact</Link>
+        <Link className="example--header-links" href="#">
+          Contact
+        </Link>
       </div>
       <div className="example--search-box">
         <Textbox className="example--header-text-box" placeholder="Bijvoorbeeld zwembad of grofvuil" />


### PR DESCRIPTION
the links on the header couldn't be tabbed through because they were missing an href so they were being seen as text instead of as links. Added hrefs to the links (empty for now) and that fixed the issue.