### PR TITLE
fix: add tokens to the data-list

### DIFF
--- a/packages/next-templates/src/app/globals.css
+++ b/packages/next-templates/src/app/globals.css
@@ -22,8 +22,8 @@ body {
   /* HACK: these tokens are not set in voorbeeld-theme */
   --utrecht-form-field-description-margin-block-end: var(--voorbeeld-space-block-beetle);
   --utrecht-space-around: 1;
-  --utrecht-button-group-margin-block-end: 16px;
-  --utrecht-button-group-margin-block-start: 16px;
+  --utrecht-button-group-margin-block-end: 24px;
+  --utrecht-button-group-margin-block-start: 24px;
   --utrecht-link-icon-size: 18px;
   --utrecht-radio-button-size: 1em;
   --utrecht-form-field-margin-block-end: 20px;
@@ -50,6 +50,14 @@ body {
   --utrecht-radio-button-checked-border-color: var(--voorbeeld-color-violet-700);
   --utrecht-radio-button-border-color: #7a8aa0;
   --utrecht-textbox-read-only-border-color: var(--utrecht-textbox-border-color);
+  --utrecht-data-list-rows-gap: 24px;
+  --utrecht-data-list-rows-border-bottom-color: #e4e7ec;
+  --utrecht-data-list-rows-border-bottom-width: 1px;
+  --utrecht-data-list-rows-item-value-margin-block-start: 8px;
+  --utrecht-data-list-margin-block-start: 24px;
+  --utrecht-data-list-margin-block-end: 48px;
+  --utrecht-data-list-rows-item-padding-block-end: 12px;
+  --utrecht-data-list-rows-item-padding-block-start: 12px;
 
   --example-page-header-content-max-inline-size: calc(var(--utrecht-article-max-inline-size) * 1.5);
 


### PR DESCRIPTION
De tokens voor de data-list zijn nog niet helemaal handig. Om het doel te bereiken heb ik de meeste tokens gevonden, maar padding voor data-list-item is niet beschikbaar. Ik heb daar een PR bij Utrecht voor gemaakt en de design-tokens die ik daar beschikbaar stel alvast ingesteld.

Update utrecht packages after merging https://github.com/nl-design-system/utrecht/pull/2024 to make the data-list look like the design.