### PR TITLE
fix: add whitespace before e-mail in confirmation message

### DIFF
--- a/packages/next-templates/src/app/wmebv/ingelogd/stap4/page.tsx
+++ b/packages/next-templates/src/app/wmebv/ingelogd/stap4/page.tsx
@@ -19,6 +19,7 @@ import { ExampleHeaderFunnelWmebv } from '@/components/wmebv/Header/ExampleHeade
 import '@/app/styling/css/wmebv.css';
 import { ContactFormSessionData, FORM_SESSION_KEY, useSessionState } from '../../SessionData';
 import { ExampleFooterWmebv } from '@/components/wmebv/Footer/ExampleFooterWmebv';
+import { ExampleSuccessPage } from '@/components/wmebv/SuccessPage';
 
 export default function home() {
   const userdata = {
@@ -36,56 +37,7 @@ export default function home() {
   return (
     <UtrechtPage>
       <ExampleHeaderFunnelWmebv userURL={userdata.userURL} username={userdata.username} />
-      <UtrechtPageContent className="voorbeeld-page-content-flex">
-        <UtrechtArticle id="main" className="voorbeeld-article-space ">
-          <UtrechtAlert type="ok" className="utrecht-spotlight-section-wmebv">
-            <UtrechtHeading1>
-              <UtrechtIcon
-                style={{
-                  '--utrecht-icon-color': 'var(--_utrecht-alert-icon-color, currentColor)',
-                }}
-              >
-                <IconCircleCheck size={33} />
-              </UtrechtIcon>
-              Uw vraag is met succes verstuurd
-            </UtrechtHeading1>
-            <UtrechtParagraph>Kenmerk: {storedData?.code}</UtrechtParagraph>
-          </UtrechtAlert>
-          <UtrechtHeading2>Wat gaat er nu gebeuren?</UtrechtHeading2>
-          <UnorderedList>
-            <UnorderedListItem>
-              U ontvangt een bevestigingsmail op
-              <Strong>
-                <UtrechtUrlData>{storedData?.email}</UtrechtUrlData>
-              </Strong>
-            </UnorderedListItem>
-            <UnorderedListItem>De afdeling Vraagbaak gaat met uw vraag aan de slag.</UnorderedListItem>
-          </UnorderedList>
-          <UtrechtButtonGroup direction="column">
-            <UtrechtLink href="#">
-              <UtrechtIcon>
-                <IconPrinter />
-              </UtrechtIcon>
-              Print uw vraag
-            </UtrechtLink>
-            <UtrechtLink href="/" download="vraag.pdf">
-              <UtrechtIcon>
-                <IconFileText />
-              </UtrechtIcon>
-              Download uw vraag als PDF
-            </UtrechtLink>
-            <UtrechtLink
-              href="/wmebv"
-              onClick={() => {
-                removeStoredData();
-                location.assign('/wmebv');
-              }}
-            >
-              Terug naar voorbeeld.nl
-            </UtrechtLink>
-          </UtrechtButtonGroup>
-        </UtrechtArticle>
-      </UtrechtPageContent>
+      <ExampleSuccessPage storedData={storedData} removeStoredData={removeStoredData} />
       <ExampleFooterWmebv />
     </UtrechtPage>
   );

--- a/packages/next-templates/src/app/wmebv/niet-ingelogd/stap4/page.tsx
+++ b/packages/next-templates/src/app/wmebv/niet-ingelogd/stap4/page.tsx
@@ -1,24 +1,11 @@
 'use client';
 
-import {
-  UtrechtArticle,
-  UtrechtHeading1,
-  UtrechtPage,
-  UtrechtPageContent,
-  UtrechtParagraph,
-  UtrechtLink,
-  UtrechtButtonGroup,
-  UtrechtIcon,
-  UtrechtAlert,
-  UtrechtHeading2,
-  UtrechtUrlData,
-} from '@utrecht/web-component-library-react';
-import { Strong, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
-import { IconPrinter, IconCircleCheck, IconFileText } from '@tabler/icons-react';
+import { UtrechtPage } from '@utrecht/web-component-library-react';
 import '@/app/styling/css/wmebv.css';
 import { ContactFormSessionData, FORM_SESSION_KEY, useSessionState } from '../../SessionData';
 import { ExampleFooterWmebv } from '@/components/wmebv/Footer/ExampleFooterWmebv';
 import { ExampleHeaderFunnelWmebv } from '@/components/wmebv/Header/ExampleHeaderFunnelWmebv';
+import { ExampleSuccessPage } from '@/components/wmebv/SuccessPage';
 
 export default function home() {
   const data = {
@@ -30,56 +17,7 @@ export default function home() {
   return (
     <UtrechtPage>
       <ExampleHeaderFunnelWmebv />
-      <UtrechtPageContent className="voorbeeld-page-content-flex">
-        <UtrechtArticle id="main" className="voorbeeld-article-space ">
-          <UtrechtAlert type="ok" className="utrecht-spotlight-section-wmebv">
-            <UtrechtHeading1>
-              <UtrechtIcon
-                style={{
-                  '--utrecht-icon-color': 'var(--_utrecht-alert-icon-color, currentColor)',
-                }}
-              >
-                <IconCircleCheck size={33} />
-              </UtrechtIcon>
-              Uw vraag is met succes verstuurd
-            </UtrechtHeading1>
-            <UtrechtParagraph>Kenmerk: {storedData?.code}</UtrechtParagraph>
-          </UtrechtAlert>
-          <UtrechtHeading2>Wat gaat er nu gebeuren?</UtrechtHeading2>
-          <UnorderedList>
-            <UnorderedListItem>
-              U ontvangt een bevestigingsmail op
-              <Strong>
-                <UtrechtUrlData>{storedData?.email}</UtrechtUrlData>
-              </Strong>
-            </UnorderedListItem>
-            <UnorderedListItem>De afdeling Vraagbaak gaat met uw vraag aan de slag.</UnorderedListItem>
-          </UnorderedList>
-          <UtrechtButtonGroup direction="column">
-            <UtrechtLink href="#">
-              <UtrechtIcon>
-                <IconPrinter />
-              </UtrechtIcon>
-              Print uw vraag
-            </UtrechtLink>
-            <UtrechtLink href="/" download="vraag.pdf">
-              <UtrechtIcon>
-                <IconFileText />
-              </UtrechtIcon>
-              Download uw vraag als PDF
-            </UtrechtLink>
-            <UtrechtLink
-              href="/wmebv"
-              onClick={() => {
-                removeStoredData();
-                location.assign('/wmebv');
-              }}
-            >
-              Terug naar voorbeeld.nl
-            </UtrechtLink>
-          </UtrechtButtonGroup>
-        </UtrechtArticle>
-      </UtrechtPageContent>
+      <ExampleSuccessPage storedData={storedData} removeStoredData={removeStoredData} />
       <ExampleFooterWmebv />
     </UtrechtPage>
   );

--- a/packages/next-templates/src/components/wmebv/SuccessPage/index.tsx
+++ b/packages/next-templates/src/components/wmebv/SuccessPage/index.tsx
@@ -1,0 +1,76 @@
+import { Strong, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
+import React, { HTMLAttributes } from 'react';
+import { IconCircleCheck, IconPrinter, IconFileText } from '@tabler/icons-react';
+import {
+  UtrechtPageContent,
+  UtrechtArticle,
+  UtrechtAlert,
+  UtrechtHeading1,
+  UtrechtIcon,
+  UtrechtParagraph,
+  UtrechtHeading2,
+  UtrechtUrlData,
+  UtrechtButtonGroup,
+  UtrechtLink,
+} from '@utrecht/web-component-library-react';
+import { ContactFormSessionData } from '@/app/wmebv/SessionData';
+
+interface ExampleSuccessPageProps extends HTMLAttributes<HTMLDivElement> {
+  storedData: ContactFormSessionData;
+  removeStoredData: () => void;
+}
+
+export const ExampleSuccessPage = ({ storedData, removeStoredData }: ExampleSuccessPageProps) => (
+  <UtrechtPageContent className="voorbeeld-page-content-flex">
+    <UtrechtArticle id="main" className="voorbeeld-article-space ">
+      <UtrechtAlert type="ok" className="utrecht-spotlight-section-wmebv">
+        <UtrechtHeading1>
+          <UtrechtIcon
+            style={{
+              '--utrecht-icon-color': 'var(--_utrecht-alert-icon-color, currentColor)',
+            }}
+          >
+            <IconCircleCheck size={33} />
+          </UtrechtIcon>
+          Uw vraag is met succes verstuurd
+        </UtrechtHeading1>
+        <UtrechtParagraph>Kenmerk: {storedData?.code}</UtrechtParagraph>
+      </UtrechtAlert>
+      <UtrechtHeading2>Wat gaat er nu gebeuren?</UtrechtHeading2>
+      <UnorderedList>
+        <UnorderedListItem>
+          U ontvangt een bevestigingsmail op{' '}
+          <Strong>
+            <UtrechtUrlData>{storedData?.email}</UtrechtUrlData>
+          </Strong>
+        </UnorderedListItem>
+        <UnorderedListItem>De afdeling Vraagbaak gaat met uw vraag aan de slag.</UnorderedListItem>
+      </UnorderedList>
+      <UtrechtButtonGroup direction="column">
+        <UtrechtLink href="#">
+          <UtrechtIcon>
+            <IconPrinter />
+          </UtrechtIcon>
+          Print uw vraag
+        </UtrechtLink>
+        <UtrechtLink href="/" download="vraag.pdf">
+          <UtrechtIcon>
+            <IconFileText />
+          </UtrechtIcon>
+          Download uw vraag als PDF
+        </UtrechtLink>
+        <UtrechtLink
+          href="/wmebv"
+          onClick={() => {
+            removeStoredData();
+            location.assign('/wmebv');
+          }}
+        >
+          Terug naar voorbeeld.nl
+        </UtrechtLink>
+      </UtrechtButtonGroup>
+    </UtrechtArticle>
+  </UtrechtPageContent>
+);
+
+ExampleSuccessPage.displayName = 'ExampleSuccessPage';


### PR DESCRIPTION
As both pages are identical instead of fixing the whitespace in both I've refactored the pages to reuse a template.

- [x] Reuse success template
- [x] Fix whitespace before e-mail in confirmation message