### PR TITLE
refactor: create common decoration tokens

### DIFF
--- a/packages/next-templates/src/app/globals.css
+++ b/packages/next-templates/src/app/globals.css
@@ -20,6 +20,8 @@ body {
 
 .voorbeeld-theme {
   /* HACK: these tokens are not set in voorbeeld-theme */
+  --voorbeeld-decoration-background-color: var(--voorbeeld-color-violet-700);
+  --voorbeeld-decoration-color: var(--voorbeeld-color-violet-700);
   --utrecht-form-field-description-margin-block-end: var(--voorbeeld-space-block-beetle);
   --utrecht-space-around: 1;
   --utrecht-form-field-error-message-margin-block-end: 0;
@@ -31,7 +33,7 @@ body {
   --utrecht-form-field-margin-block-start: var(--voorbeeld-space-block-rabbit);
   --utrecht-form-field-label-margin-block-end: var(--voorbeeld-space-block-beetle);
   --utrecht-paragraph-margin-block-end: var(--voorbeeld-space-block-rabbit);
-  --utrecht-page-footer-background-color: var(--voorbeeld-color-violet-700);
+  --utrecht-page-footer-background-color: var(--voorbeeld-decoration-background-color);
   --utrecht-spotlight-section-background-color: var(--voorbeeld-color-violet-100);
   --utrecht-spotlight-section-color: var(--voorbeeld-color-gray-900);
   --utrecht-heading-1-margin-block-start: 0;
@@ -55,10 +57,10 @@ body {
   --utrecht-radio-button-icon-size: 0%;
   --utrecht-radio-button-size: 1.5em;
   --utrecht-radio-button-checked-border-width: 0.6em;
-  --utrecht-radio-button-checked-border-color: var(--voorbeeld-color-violet-700);
+  --utrecht-radio-button-checked-border-color: var(--utrecht-interaction-color);
   --utrecht-radio-button-border-color: var(--voorbeeld-color-gray-500);
   --utrecht-textbox-read-only-border-color: var(--utrecht-textbox-border-color);
-  --voorbeeld-logo-icon-color: var(--voorbeeld-color-violet-700);
+  --voorbeeld-logo-icon-color: var(--voorbeeld-decoration-color);
   --voorbeeld-logo-color: var(--voorbeeld-color-gray-950);
 
   --example-page-header-content-max-inline-size: calc(var(--utrecht-article-max-inline-size) * 1.5);
@@ -72,7 +74,7 @@ body {
   --example-nav-bar-link-padding-block-start: var(--voorbeeld-space-block-mouse);
   --example-nav-bar-link-padding-inline-end: var(--voorbeeld-space-inline-rabbit);
   --example-nav-bar-link-padding-inline-start: var(--voorbeeld-space-inline-rabbit);
-  --example-nav-bar-background-color: var(--voorbeeld-color-violet-700);
+  --example-nav-bar-background-color: var(--voorbeeld-decoration-background-color);
   --example-nav-bar-color: var(--voorbeeld-color-white);
 
   /* alert */

--- a/packages/next-templates/src/app/styling/css/form-page.css
+++ b/packages/next-templates/src/app/styling/css/form-page.css
@@ -4,7 +4,7 @@
   --utrecht-radio-button-icon-size: 0%;
   --utrecht-radio-button-size: 1.5em;
   --utrecht-radio-button-checked-border-width: 0.5em;
-  --utrecht-radio-button-checked-border-color: var(--voorbeeld-color-violet-700);
+  --utrecht-radio-button-checked-border-color: var(--utrecht-interaction-color);
   --utrecht-radio-button-border-color: var(--voorbeeld-color-gray-500);
 }
 

--- a/packages/next-templates/src/app/styling/css/maandagochtend.css
+++ b/packages/next-templates/src/app/styling/css/maandagochtend.css
@@ -27,7 +27,7 @@
 }
 
 path {
-  fill: var(--voorbeeld-color-violet-700);
+  fill: var(--voorbeeld-decoration-color);
 }
 
 @media only screen and (max-width: 387px) {

--- a/packages/next-templates/src/app/styling/css/wmebv.css
+++ b/packages/next-templates/src/app/styling/css/wmebv.css
@@ -27,13 +27,13 @@
 }
 
 .mijn-omgeving {
-  color: var(--voorbeeld-color-violet-700);
+  color: var(--utrecht-interaction-color);
   text-decoration: underline;
 }
 
 .link {
   text-decoration: underline;
-  text-decoration-color: var(--voorbeeld-color-violet-700);
+  text-decoration-color: var(--utrecht-interaction-color);
   padding: 12px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/next-templates/src/app/styling/css/wrong-form-socks.css
+++ b/packages/next-templates/src/app/styling/css/wrong-form-socks.css
@@ -8,9 +8,9 @@
   --utrecht-textbox-focus-border-color: var(--voorbeeld-color-gray-500);
   --utrecht-textarea-focus-border-color: var(--voorbeeld-color-gray-500);
   --utrecht-button-secondary-action-focus-background-color: transparent;
-  --utrecht-button-secondary-action-focus-border-color: var(--voorbeeld-color-violet-700);
-  --utrecht-button-secondary-action-focus-color: var(--voorbeeld-color-violet-700);
-  --utrecht-button-primary-action-focus-background-color: var(--voorbeeld-color-violet-700);
+  --utrecht-button-secondary-action-focus-border-color: var(--voorbeeld-decoration-color);
+  --utrecht-button-secondary-action-focus-color: var(--voorbeeld-decoration-color);
+  --utrecht-button-primary-action-focus-background-color: var(--voorbeeld-decoration-background-color);
   --utrecht-button-primary-action-focus-color: var(--voorbeeld-color-white);
   --utrecht-focus-outline-color: transparent;
 }

--- a/packages/next-templates/src/components/ExampleHeader/ExampleHeaderFunnel/exampleheaderfunnel.css
+++ b/packages/next-templates/src/components/ExampleHeader/ExampleHeaderFunnel/exampleheaderfunnel.css
@@ -1,6 +1,6 @@
 .example--header-home-page {
   align-items: center;
-  border-bottom: solid 4px var(--voorbeeld-color-violet-700);
+  border-bottom: solid 4px var(--voorbeeld-decoration-color);
   display: flex;
   justify-content: space-between;
   margin-block-start: 1em;

--- a/packages/next-templates/src/components/ExampleHeader/header.css
+++ b/packages/next-templates/src/components/ExampleHeader/header.css
@@ -51,7 +51,7 @@
 .example--header-burger-menu-button {
   background-color: transparent;
   border-width: 0;
-  color: var(--voorbeeld-color-violet-700);
+  color: var(--utrecht-interaction-color);
   cursor: pointer;
   display: none;
 }
@@ -62,7 +62,7 @@
 }
 
 .example--header-bar {
-  background-color: var(--voorbeeld-color-violet-700);
+  background-color: var(--voorbeeld-decoration-background-color);
   border-radius: 10px;
   display: block;
   height: 2px;
@@ -117,14 +117,14 @@
 
 @media (width <= 1185px) {
   .example-page-header__content {
-    border-bottom: solid 4px var(--voorbeeld-color-violet-700);
+    border-bottom: solid 4px var(--voorbeeld-decoration-color);
     margin-inline: auto;
     padding-inline: var(--voorbeeld-space-inline-beetle);
     padding-block: var(--voorbeeld-space-block-beetle);
   }
 
   .example--header-popover-menu {
-    background-color: var(--voorbeeld-color-violet-700);
+    background-color: var(--voorbeeld-decoration-background-color);
   }
 
   .example--header-links {

--- a/packages/next-templates/src/components/TopTask/TopTaskLink.css
+++ b/packages/next-templates/src/components/TopTask/TopTaskLink.css
@@ -2,7 +2,7 @@
   flex: calc(100% / 3);
   --utrecht-link-color: var(--voorbeeld-color-white);
   padding: var(--voorbeeld-space-inline-rabbit);
-  background-color: var(--voorbeeld-color-violet-700);
+  background-color: var(--voorbeeld-decoration-background-color);
   text-decoration: none;
 }
 


### PR DESCRIPTION
Having the following two common tokens will be helpful for when we have the theme builder:
- `voorbeeld.decoration.color`
- `voorbeeld.decoration.background-color`